### PR TITLE
Capture transcripts for /compact and /clear operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Session data is captured automatically on every Claude Code session when `CLAUDE
 
 ## How It Works
 
-Uses Claude Code's `SessionStart` and `SessionEnd` hooks to capture enrichment data.
+Uses Claude Code's `SessionStart`, `SessionEnd`, and `PreCompact` hooks to capture enrichment data.
 
 **Claude's data:** `~/.claude/projects/{project}/{session_id}.jsonl`
 
@@ -96,9 +96,31 @@ The installer also adds `permissions.deny` rules to prevent Claude from accident
       "dirty": false,
       "commits_made": ["def456"]
     }
+  },
+  "compaction_events": [
+    {
+      "timestamp": "2025-12-19T21:15:00Z",
+      "trigger": "manual",
+      "transcript_snapshot": "abc-123_precompact_001.jsonl"
+    }
+  ],
+  "clear_event": {
+    "timestamp": "2025-12-19T21:30:00Z",
+    "transcript_snapshot": "abc-123_preclear.jsonl"
   }
 }
 ```
+
+### Transcript Snapshots
+
+When you `/compact` or `/clear` a conversation, Claude Logger preserves the full transcript before the operation:
+
+| Event | Snapshot File | When Captured |
+|-------|--------------|---------------|
+| `/compact` | `{session_id}_precompact_001.jsonl` | Before each compaction |
+| `/clear` | `{session_id}_preclear.jsonl` | Before clearing |
+
+Multiple compactions increment the counter: `_precompact_001.jsonl`, `_precompact_002.jsonl`, etc.
 
 ## Documentation
 

--- a/hooks-config.json
+++ b/hooks-config.json
@@ -27,6 +27,17 @@
           }
         ]
       }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/pre_compact.sh",
+            "timeout": 10
+          }
+        ]
+      }
     ]
   }
 }

--- a/hooks/pre_compact.sh
+++ b/hooks/pre_compact.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+#
+# ╔════════════════════════════════════════════════════════════════════════════╗
+# ║  DO NOT MODIFY - This file is managed by claude-logger                     ║
+# ║  Source: https://github.com/my-entourage/claude-logger                     ║
+# ║  To update, re-run the installer from the claude-logger repository.        ║
+# ╚════════════════════════════════════════════════════════════════════════════╝
+#
+# Claude Tracker - Pre-Compact Hook
+# Captures full transcript before compaction to preserve conversation history.
+#
+# Design decisions:
+# - Same robustness principles as other hooks
+# - Captures transcript before Claude Code compacts it
+# - Supports multiple compactions per session (incremental counter)
+# - Graceful degradation on all failures
+#
+
+set -o pipefail
+
+#######################################
+# Dependencies check
+#######################################
+if ! command -v jq &>/dev/null; then
+  exit 0
+fi
+
+#######################################
+# Nickname validation
+# Returns 0 if valid, 1 if invalid
+# Valid: 1-39 chars, lowercase alphanumeric with dashes/underscores
+#######################################
+validate_nickname() {
+  local nick="$1"
+  # Check length and characters
+  if [ ${#nick} -lt 1 ] || [ ${#nick} -gt 39 ]; then
+    return 1
+  fi
+  # Check for valid characters only (lowercase alphanumeric, dash, underscore)
+  case "$nick" in
+    *[!a-z0-9_-]*) return 1 ;;
+  esac
+  return 0
+}
+
+#######################################
+# Resolve project root (git root or fallback to cwd)
+# Attempts to find the git repository root directory.
+# Falls back to provided cwd if not in a git repo or on timeout.
+#######################################
+resolve_project_root() {
+  local dir="$1"
+  local git_timeout=3
+
+  # Use GNU timeout if available
+  local timeout_cmd=""
+  if command -v timeout &>/dev/null; then
+    timeout_cmd="timeout $git_timeout"
+  fi
+
+  # Try to get git root
+  local git_root
+  git_root=$($timeout_cmd git -C "$dir" rev-parse --show-toplevel 2>/dev/null)
+
+  if [ -n "$git_root" ] && [ -d "$git_root" ]; then
+    echo "$git_root"
+  else
+    echo "$dir"
+  fi
+}
+
+#######################################
+# Read hook input
+#######################################
+HOOK_INPUT=$(cat)
+[ -z "$HOOK_INPUT" ] && exit 0
+
+#######################################
+# Parse input with validation (single jq call)
+# PreCompact hook receives: session_id, transcript_path, trigger, cwd
+#######################################
+eval "set -- $(echo "$HOOK_INPUT" | jq -r '[
+  .session_id // "",
+  .transcript_path // "",
+  .trigger // "auto",
+  .cwd // ""
+] | @sh')"
+SESSION_ID="$1"
+TRANSCRIPT_PATH="$2"
+TRIGGER="$3"
+CWD="$4"
+
+[ -z "$SESSION_ID" ] && exit 0
+[ -z "$TRANSCRIPT_PATH" ] && exit 0
+
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+# Fallback for CWD
+if [ -z "$CWD" ] || [ ! -d "$CWD" ]; then
+  CWD=$(pwd)
+fi
+
+# Resolve project root for session storage
+PROJECT_ROOT=$(resolve_project_root "$CWD")
+
+#######################################
+# Get user nickname (required for tracking)
+#######################################
+CLAUDE_LOGGER_USER="${CLAUDE_LOGGER_USER:-}"
+if [ -z "$CLAUDE_LOGGER_USER" ]; then
+  exit 0
+fi
+
+# Normalize to lowercase
+CLAUDE_LOGGER_USER=$(echo "$CLAUDE_LOGGER_USER" | tr '[:upper:]' '[:lower:]')
+
+# Validate nickname
+if ! validate_nickname "$CLAUDE_LOGGER_USER"; then
+  exit 0
+fi
+
+#######################################
+# Determine storage location (global vs project)
+#######################################
+if [ -f "$HOME/.claude-logger/global-mode" ]; then
+  SESSIONS_DIR="$HOME/.claude-logger/sessions/$CLAUDE_LOGGER_USER"
+else
+  SESSIONS_DIR="$PROJECT_ROOT/.claude/sessions/$CLAUDE_LOGGER_USER"
+fi
+
+#######################################
+# Verify session file exists
+#######################################
+SESSION_FILE="$SESSIONS_DIR/$SESSION_ID.json"
+if [ ! -f "$SESSION_FILE" ] || [ ! -r "$SESSION_FILE" ]; then
+  exit 0
+fi
+
+#######################################
+# Check transcript exists and has content
+#######################################
+if [ ! -f "$TRANSCRIPT_PATH" ] || [ ! -s "$TRANSCRIPT_PATH" ]; then
+  exit 0
+fi
+
+#######################################
+# Determine next compaction counter
+# Count existing precompact files for this session
+#######################################
+get_next_counter() {
+  local count=0
+  for f in "$SESSIONS_DIR/${SESSION_ID}_precompact_"*.jsonl; do
+    [ -f "$f" ] && ((count++))
+  done
+  printf "%03d" $((count + 1))
+}
+
+COUNTER=$(get_next_counter)
+SNAPSHOT_FILE="$SESSIONS_DIR/${SESSION_ID}_precompact_${COUNTER}.jsonl"
+
+#######################################
+# Copy transcript to snapshot file
+#######################################
+cp "$TRANSCRIPT_PATH" "$SNAPSHOT_FILE" 2>/dev/null || exit 0
+
+#######################################
+# Update session file with compaction event
+#######################################
+TMP_FILE="$SESSION_FILE.tmp.$$"
+
+# Add compaction event to session JSON
+jq \
+  --arg timestamp "$TIMESTAMP" \
+  --arg trigger "$TRIGGER" \
+  --arg snapshot "${SESSION_ID}_precompact_${COUNTER}.jsonl" \
+  '.compaction_events = (.compaction_events // []) + [{
+    timestamp: $timestamp,
+    trigger: $trigger,
+    transcript_snapshot: $snapshot
+  }]' "$SESSION_FILE" > "$TMP_FILE" 2>/dev/null
+
+# Atomic move (only if write succeeded and produced valid JSON)
+if [ -s "$TMP_FILE" ] && jq -e '.' "$TMP_FILE" &>/dev/null; then
+  mv "$TMP_FILE" "$SESSION_FILE" 2>/dev/null
+else
+  rm -f "$TMP_FILE" 2>/dev/null
+fi
+
+exit 0

--- a/hooks/tests/test_pre_compact.sh
+++ b/hooks/tests/test_pre_compact.sh
@@ -1,0 +1,503 @@
+#!/usr/bin/env bash
+#
+# Tests for pre_compact.sh hook
+#
+
+#######################################
+# Helper: Create a started session
+#######################################
+create_started_session_for_compact() {
+  local session_id="$1"
+  local session_file="$TEST_TMPDIR/.claude/sessions/$CLAUDE_LOGGER_USER/$session_id.json"
+  local transcript_path="${2:-/tmp/test.jsonl}"
+
+  cat > "$session_file" << EOF
+{
+  "schema_version": 1,
+  "session_id": "$session_id",
+  "transcript_path": "$transcript_path",
+  "status": "in_progress",
+  "start": {
+    "timestamp": "2025-01-01T12:00:00Z",
+    "cwd": "$TEST_TMPDIR",
+    "source": "startup",
+    "git": {
+      "sha": "abc123def456",
+      "branch": "main",
+      "is_repo": true
+    }
+  }
+}
+EOF
+}
+
+#######################################
+# Helper: Create a fake transcript file
+#######################################
+create_transcript() {
+  local path="$1"
+  echo '{"type":"user","message":"hello"}' > "$path"
+  echo '{"type":"assistant","message":"hi there"}' >> "$path"
+  echo '{"type":"user","message":"help me code"}' >> "$path"
+}
+
+#######################################
+# Test: Basic pre-compact transcript capture
+#######################################
+test_start "pre_compact: captures transcript before compaction"
+setup_test_env
+
+# Copy the pre_compact hook
+cp "$(dirname "$0")/../pre_compact.sh" "$TEST_TMPDIR/.claude/hooks/"
+chmod +x "$TEST_TMPDIR/.claude/hooks/pre_compact.sh"
+
+# Create transcript
+transcript_file="/tmp/test-compact-$$.jsonl"
+create_transcript "$transcript_file"
+
+create_started_session_for_compact "test-compact" "$transcript_file"
+
+input='{"session_id":"test-compact","cwd":"'"$TEST_TMPDIR"'","transcript_path":"'"$transcript_file"'","trigger":"manual"}'
+echo "$input" | bash "$TEST_TMPDIR/.claude/hooks/pre_compact.sh"
+
+# Check snapshot was created
+snapshot="$TEST_TMPDIR/.claude/sessions/$CLAUDE_LOGGER_USER/test-compact_precompact_001.jsonl"
+if assert_file_exists "$snapshot"; then
+  # Verify content matches
+  if diff -q "$transcript_file" "$snapshot" >/dev/null 2>&1; then
+    test_pass "Transcript snapshot created and matches"
+  else
+    test_fail "Transcript content mismatch"
+  fi
+fi
+
+rm -f "$transcript_file"
+cleanup_test_env
+
+#######################################
+# Test: Session JSON updated with compaction event
+#######################################
+test_start "pre_compact: updates session JSON with compaction event"
+setup_test_env
+
+cp "$(dirname "$0")/../pre_compact.sh" "$TEST_TMPDIR/.claude/hooks/"
+chmod +x "$TEST_TMPDIR/.claude/hooks/pre_compact.sh"
+
+transcript_file="/tmp/test-compact-event-$$.jsonl"
+create_transcript "$transcript_file"
+
+create_started_session_for_compact "test-event" "$transcript_file"
+
+input='{"session_id":"test-event","cwd":"'"$TEST_TMPDIR"'","transcript_path":"'"$transcript_file"'","trigger":"manual"}'
+echo "$input" | bash "$TEST_TMPDIR/.claude/hooks/pre_compact.sh"
+
+session_file="$TEST_TMPDIR/.claude/sessions/$CLAUDE_LOGGER_USER/test-event.json"
+
+# Check compaction_events was added
+if jq -e '.compaction_events' "$session_file" &>/dev/null; then
+  trigger=$(jq -r '.compaction_events[0].trigger' "$session_file")
+  snapshot=$(jq -r '.compaction_events[0].transcript_snapshot' "$session_file")
+
+  if [ "$trigger" = "manual" ] && [ "$snapshot" = "test-event_precompact_001.jsonl" ]; then
+    test_pass "Compaction event recorded correctly"
+  else
+    test_fail "Compaction event data incorrect (trigger: $trigger, snapshot: $snapshot)"
+  fi
+else
+  test_fail "compaction_events not added to session JSON"
+fi
+
+rm -f "$transcript_file"
+cleanup_test_env
+
+#######################################
+# Test: Auto trigger type
+#######################################
+test_start "pre_compact: captures auto trigger type"
+setup_test_env
+
+cp "$(dirname "$0")/../pre_compact.sh" "$TEST_TMPDIR/.claude/hooks/"
+chmod +x "$TEST_TMPDIR/.claude/hooks/pre_compact.sh"
+
+transcript_file="/tmp/test-auto-$$.jsonl"
+create_transcript "$transcript_file"
+
+create_started_session_for_compact "test-auto" "$transcript_file"
+
+input='{"session_id":"test-auto","cwd":"'"$TEST_TMPDIR"'","transcript_path":"'"$transcript_file"'","trigger":"auto"}'
+echo "$input" | bash "$TEST_TMPDIR/.claude/hooks/pre_compact.sh"
+
+session_file="$TEST_TMPDIR/.claude/sessions/$CLAUDE_LOGGER_USER/test-auto.json"
+trigger=$(jq -r '.compaction_events[0].trigger' "$session_file")
+
+if [ "$trigger" = "auto" ]; then
+  test_pass "Auto trigger recorded"
+else
+  test_fail "Expected 'auto' trigger, got '$trigger'"
+fi
+
+rm -f "$transcript_file"
+cleanup_test_env
+
+#######################################
+# Test: Multiple compactions increment counter
+#######################################
+test_start "pre_compact: increments counter for multiple compactions"
+setup_test_env
+
+cp "$(dirname "$0")/../pre_compact.sh" "$TEST_TMPDIR/.claude/hooks/"
+chmod +x "$TEST_TMPDIR/.claude/hooks/pre_compact.sh"
+
+transcript_file="/tmp/test-multi-$$.jsonl"
+create_transcript "$transcript_file"
+
+create_started_session_for_compact "test-multi" "$transcript_file"
+
+# First compaction
+input='{"session_id":"test-multi","cwd":"'"$TEST_TMPDIR"'","transcript_path":"'"$transcript_file"'","trigger":"manual"}'
+echo "$input" | bash "$TEST_TMPDIR/.claude/hooks/pre_compact.sh"
+
+# Second compaction
+echo '{"type":"more","data":"content"}' >> "$transcript_file"
+echo "$input" | bash "$TEST_TMPDIR/.claude/hooks/pre_compact.sh"
+
+# Third compaction
+echo '{"type":"even","more":"data"}' >> "$transcript_file"
+echo "$input" | bash "$TEST_TMPDIR/.claude/hooks/pre_compact.sh"
+
+# Check all three snapshots exist
+snap1="$TEST_TMPDIR/.claude/sessions/$CLAUDE_LOGGER_USER/test-multi_precompact_001.jsonl"
+snap2="$TEST_TMPDIR/.claude/sessions/$CLAUDE_LOGGER_USER/test-multi_precompact_002.jsonl"
+snap3="$TEST_TMPDIR/.claude/sessions/$CLAUDE_LOGGER_USER/test-multi_precompact_003.jsonl"
+
+if [ -f "$snap1" ] && [ -f "$snap2" ] && [ -f "$snap3" ]; then
+  # Check session JSON has 3 compaction events
+  session_file="$TEST_TMPDIR/.claude/sessions/$CLAUDE_LOGGER_USER/test-multi.json"
+  count=$(jq '.compaction_events | length' "$session_file")
+
+  if [ "$count" -eq 3 ]; then
+    test_pass "Three compaction snapshots created"
+  else
+    test_fail "Expected 3 compaction events, got $count"
+  fi
+else
+  test_fail "Not all snapshots created"
+fi
+
+rm -f "$transcript_file"
+cleanup_test_env
+
+#######################################
+# Test: Empty input handling
+#######################################
+test_start "pre_compact: handles empty input gracefully"
+setup_test_env
+
+cp "$(dirname "$0")/../pre_compact.sh" "$TEST_TMPDIR/.claude/hooks/"
+chmod +x "$TEST_TMPDIR/.claude/hooks/pre_compact.sh"
+
+echo "" | bash "$TEST_TMPDIR/.claude/hooks/pre_compact.sh"
+
+# Should not create any snapshot files
+snapshots=$(ls "$TEST_TMPDIR/.claude/sessions/$CLAUDE_LOGGER_USER/"*_precompact_*.jsonl 2>/dev/null | wc -l | tr -d ' ')
+if [ "$snapshots" -eq 0 ]; then
+  test_pass "No snapshot created for empty input"
+else
+  test_fail "Snapshot created for empty input"
+fi
+
+cleanup_test_env
+
+#######################################
+# Test: Missing session_id
+#######################################
+test_start "pre_compact: handles missing session_id gracefully"
+setup_test_env
+
+cp "$(dirname "$0")/../pre_compact.sh" "$TEST_TMPDIR/.claude/hooks/"
+chmod +x "$TEST_TMPDIR/.claude/hooks/pre_compact.sh"
+
+input='{"cwd":"'"$TEST_TMPDIR"'","transcript_path":"/tmp/test.jsonl","trigger":"manual"}'
+echo "$input" | bash "$TEST_TMPDIR/.claude/hooks/pre_compact.sh"
+
+snapshots=$(ls "$TEST_TMPDIR/.claude/sessions/$CLAUDE_LOGGER_USER/"*_precompact_*.jsonl 2>/dev/null | wc -l | tr -d ' ')
+if [ "$snapshots" -eq 0 ]; then
+  test_pass "No snapshot created without session_id"
+else
+  test_fail "Snapshot created without session_id"
+fi
+
+cleanup_test_env
+
+#######################################
+# Test: Missing transcript_path
+#######################################
+test_start "pre_compact: handles missing transcript_path gracefully"
+setup_test_env
+
+cp "$(dirname "$0")/../pre_compact.sh" "$TEST_TMPDIR/.claude/hooks/"
+chmod +x "$TEST_TMPDIR/.claude/hooks/pre_compact.sh"
+
+create_started_session_for_compact "test-no-transcript"
+
+input='{"session_id":"test-no-transcript","cwd":"'"$TEST_TMPDIR"'","trigger":"manual"}'
+echo "$input" | bash "$TEST_TMPDIR/.claude/hooks/pre_compact.sh"
+
+snapshots=$(ls "$TEST_TMPDIR/.claude/sessions/$CLAUDE_LOGGER_USER/"*_precompact_*.jsonl 2>/dev/null | wc -l | tr -d ' ')
+if [ "$snapshots" -eq 0 ]; then
+  test_pass "No snapshot created without transcript_path"
+else
+  test_fail "Snapshot created without transcript_path"
+fi
+
+cleanup_test_env
+
+#######################################
+# Test: Non-existent transcript file
+#######################################
+test_start "pre_compact: handles non-existent transcript file"
+setup_test_env
+
+cp "$(dirname "$0")/../pre_compact.sh" "$TEST_TMPDIR/.claude/hooks/"
+chmod +x "$TEST_TMPDIR/.claude/hooks/pre_compact.sh"
+
+create_started_session_for_compact "test-missing-file"
+
+input='{"session_id":"test-missing-file","cwd":"'"$TEST_TMPDIR"'","transcript_path":"/nonexistent/path/transcript.jsonl","trigger":"manual"}'
+echo "$input" | bash "$TEST_TMPDIR/.claude/hooks/pre_compact.sh"
+
+snapshots=$(ls "$TEST_TMPDIR/.claude/sessions/$CLAUDE_LOGGER_USER/"*_precompact_*.jsonl 2>/dev/null | wc -l | tr -d ' ')
+if [ "$snapshots" -eq 0 ]; then
+  test_pass "No snapshot created for non-existent transcript"
+else
+  test_fail "Snapshot created for non-existent transcript"
+fi
+
+cleanup_test_env
+
+#######################################
+# Test: Empty transcript file
+#######################################
+test_start "pre_compact: handles empty transcript file"
+setup_test_env
+
+cp "$(dirname "$0")/../pre_compact.sh" "$TEST_TMPDIR/.claude/hooks/"
+chmod +x "$TEST_TMPDIR/.claude/hooks/pre_compact.sh"
+
+# Create empty transcript
+transcript_file="/tmp/test-empty-$$.jsonl"
+touch "$transcript_file"
+
+create_started_session_for_compact "test-empty-transcript" "$transcript_file"
+
+input='{"session_id":"test-empty-transcript","cwd":"'"$TEST_TMPDIR"'","transcript_path":"'"$transcript_file"'","trigger":"manual"}'
+echo "$input" | bash "$TEST_TMPDIR/.claude/hooks/pre_compact.sh"
+
+snapshots=$(ls "$TEST_TMPDIR/.claude/sessions/$CLAUDE_LOGGER_USER/"*_precompact_*.jsonl 2>/dev/null | wc -l | tr -d ' ')
+if [ "$snapshots" -eq 0 ]; then
+  test_pass "No snapshot created for empty transcript"
+else
+  test_fail "Snapshot created for empty transcript"
+fi
+
+rm -f "$transcript_file"
+cleanup_test_env
+
+#######################################
+# Test: Non-existent session file
+#######################################
+test_start "pre_compact: handles non-existent session file"
+setup_test_env
+
+cp "$(dirname "$0")/../pre_compact.sh" "$TEST_TMPDIR/.claude/hooks/"
+chmod +x "$TEST_TMPDIR/.claude/hooks/pre_compact.sh"
+
+transcript_file="/tmp/test-no-session-$$.jsonl"
+create_transcript "$transcript_file"
+
+# Don't create session file
+
+input='{"session_id":"nonexistent-session","cwd":"'"$TEST_TMPDIR"'","transcript_path":"'"$transcript_file"'","trigger":"manual"}'
+echo "$input" | bash "$TEST_TMPDIR/.claude/hooks/pre_compact.sh"
+
+snapshots=$(ls "$TEST_TMPDIR/.claude/sessions/$CLAUDE_LOGGER_USER/"*_precompact_*.jsonl 2>/dev/null | wc -l | tr -d ' ')
+if [ "$snapshots" -eq 0 ]; then
+  test_pass "No snapshot created for non-existent session"
+else
+  test_fail "Snapshot created for non-existent session"
+fi
+
+rm -f "$transcript_file"
+cleanup_test_env
+
+#######################################
+# Test: Default trigger to auto
+#######################################
+test_start "pre_compact: defaults trigger to 'auto' when missing"
+setup_test_env
+
+cp "$(dirname "$0")/../pre_compact.sh" "$TEST_TMPDIR/.claude/hooks/"
+chmod +x "$TEST_TMPDIR/.claude/hooks/pre_compact.sh"
+
+transcript_file="/tmp/test-default-$$.jsonl"
+create_transcript "$transcript_file"
+
+create_started_session_for_compact "test-default" "$transcript_file"
+
+# No trigger in input
+input='{"session_id":"test-default","cwd":"'"$TEST_TMPDIR"'","transcript_path":"'"$transcript_file"'"}'
+echo "$input" | bash "$TEST_TMPDIR/.claude/hooks/pre_compact.sh"
+
+session_file="$TEST_TMPDIR/.claude/sessions/$CLAUDE_LOGGER_USER/test-default.json"
+trigger=$(jq -r '.compaction_events[0].trigger' "$session_file")
+
+if [ "$trigger" = "auto" ]; then
+  test_pass "Default trigger is 'auto'"
+else
+  test_fail "Expected default trigger 'auto', got '$trigger'"
+fi
+
+rm -f "$transcript_file"
+cleanup_test_env
+
+#######################################
+# Test: Timestamp recorded
+#######################################
+test_start "pre_compact: records timestamp in compaction event"
+setup_test_env
+
+cp "$(dirname "$0")/../pre_compact.sh" "$TEST_TMPDIR/.claude/hooks/"
+chmod +x "$TEST_TMPDIR/.claude/hooks/pre_compact.sh"
+
+transcript_file="/tmp/test-ts-$$.jsonl"
+create_transcript "$transcript_file"
+
+create_started_session_for_compact "test-timestamp" "$transcript_file"
+
+input='{"session_id":"test-timestamp","cwd":"'"$TEST_TMPDIR"'","transcript_path":"'"$transcript_file"'","trigger":"manual"}'
+echo "$input" | bash "$TEST_TMPDIR/.claude/hooks/pre_compact.sh"
+
+session_file="$TEST_TMPDIR/.claude/sessions/$CLAUDE_LOGGER_USER/test-timestamp.json"
+timestamp=$(jq -r '.compaction_events[0].timestamp' "$session_file")
+
+# Verify it's a valid ISO timestamp
+if [[ "$timestamp" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]; then
+  test_pass "Valid timestamp recorded: $timestamp"
+else
+  test_fail "Invalid timestamp: $timestamp"
+fi
+
+rm -f "$transcript_file"
+cleanup_test_env
+
+#######################################
+# Test: Session from git subdirectory
+#######################################
+test_start "pre_compact: finds session in git root from subdirectory"
+setup_test_env
+
+cp "$(dirname "$0")/../pre_compact.sh" "$TEST_TMPDIR/.claude/hooks/"
+chmod +x "$TEST_TMPDIR/.claude/hooks/pre_compact.sh"
+
+git -C "$TEST_TMPDIR" init -q
+mkdir -p "$TEST_TMPDIR/src/components"
+
+transcript_file="/tmp/test-subdir-$$.jsonl"
+create_transcript "$transcript_file"
+
+# Session file in git root
+create_started_session_for_compact "test-subdir" "$transcript_file"
+
+# Run from subdirectory
+input='{"session_id":"test-subdir","cwd":"'"$TEST_TMPDIR/src/components"'","transcript_path":"'"$transcript_file"'","trigger":"manual"}'
+echo "$input" | bash "$TEST_TMPDIR/.claude/hooks/pre_compact.sh"
+
+# Snapshot should be in git root sessions dir
+snapshot="$TEST_TMPDIR/.claude/sessions/$CLAUDE_LOGGER_USER/test-subdir_precompact_001.jsonl"
+if [ -f "$snapshot" ]; then
+  test_pass "Snapshot created in git root"
+else
+  test_fail "Snapshot not created in expected location"
+fi
+
+rm -f "$transcript_file"
+cleanup_test_env
+
+#######################################
+# Test: Invalid JSON input
+#######################################
+test_start "pre_compact: handles invalid JSON gracefully"
+setup_test_env
+
+cp "$(dirname "$0")/../pre_compact.sh" "$TEST_TMPDIR/.claude/hooks/"
+chmod +x "$TEST_TMPDIR/.claude/hooks/pre_compact.sh"
+
+echo "not valid json at all" | bash "$TEST_TMPDIR/.claude/hooks/pre_compact.sh"
+
+snapshots=$(ls "$TEST_TMPDIR/.claude/sessions/$CLAUDE_LOGGER_USER/"*_precompact_*.jsonl 2>/dev/null | wc -l | tr -d ' ')
+if [ "$snapshots" -eq 0 ]; then
+  test_pass "No snapshot created for invalid JSON"
+else
+  test_fail "Snapshot created for invalid JSON"
+fi
+
+cleanup_test_env
+
+#######################################
+# Test: Preserves existing compaction_events
+#######################################
+test_start "pre_compact: preserves existing compaction_events"
+setup_test_env
+
+cp "$(dirname "$0")/../pre_compact.sh" "$TEST_TMPDIR/.claude/hooks/"
+chmod +x "$TEST_TMPDIR/.claude/hooks/pre_compact.sh"
+
+transcript_file="/tmp/test-preserve-$$.jsonl"
+create_transcript "$transcript_file"
+
+# Create session with existing compaction_events
+session_file="$TEST_TMPDIR/.claude/sessions/$CLAUDE_LOGGER_USER/test-preserve.json"
+cat > "$session_file" << EOF
+{
+  "schema_version": 1,
+  "session_id": "test-preserve",
+  "transcript_path": "$transcript_file",
+  "status": "in_progress",
+  "compaction_events": [
+    {
+      "timestamp": "2025-01-01T10:00:00Z",
+      "trigger": "manual",
+      "transcript_snapshot": "test-preserve_precompact_001.jsonl"
+    }
+  ],
+  "start": {
+    "timestamp": "2025-01-01T12:00:00Z"
+  }
+}
+EOF
+
+# Create fake existing snapshot
+touch "$TEST_TMPDIR/.claude/sessions/$CLAUDE_LOGGER_USER/test-preserve_precompact_001.jsonl"
+
+input='{"session_id":"test-preserve","cwd":"'"$TEST_TMPDIR"'","transcript_path":"'"$transcript_file"'","trigger":"auto"}'
+echo "$input" | bash "$TEST_TMPDIR/.claude/hooks/pre_compact.sh"
+
+# Check both events exist
+count=$(jq '.compaction_events | length' "$session_file")
+if [ "$count" -eq 2 ]; then
+  # Check the new one is _002
+  second_snapshot=$(jq -r '.compaction_events[1].transcript_snapshot' "$session_file")
+  if [ "$second_snapshot" = "test-preserve_precompact_002.jsonl" ]; then
+    test_pass "Existing events preserved, new event added"
+  else
+    test_fail "New event has wrong snapshot name: $second_snapshot"
+  fi
+else
+  test_fail "Expected 2 compaction events, got $count"
+fi
+
+rm -f "$transcript_file"
+cleanup_test_env
+
+echo ""
+echo "pre_compact.sh tests complete"

--- a/hooks/tests/test_runner.sh
+++ b/hooks/tests/test_runner.sh
@@ -50,6 +50,7 @@ setup_test_env() {
   # Copy hooks to test directory
   cp "$(dirname "$0")/../session_start.sh" "$TEST_TMPDIR/.claude/hooks/"
   cp "$(dirname "$0")/../session_end.sh" "$TEST_TMPDIR/.claude/hooks/"
+  cp "$(dirname "$0")/../pre_compact.sh" "$TEST_TMPDIR/.claude/hooks/"
   chmod +x "$TEST_TMPDIR/.claude/hooks/"*.sh
 }
 


### PR DESCRIPTION
## Summary

Adds transcript capture functionality for `/compact` and `/clear` operations:

- **`/clear`** creates a new session JSON and JSONL file while preserving the pre-clear conversation as a transcript
- **`/compact`** preserves the conversation as a pre-compact transcript with sequential numbering within the same session (does not create a new session)

## Testing

All existing tests pass. Hook tests verify correct transcript capture and file handling for both operations.