### PR TITLE
feat: organize global sessions by git org/repo instead of username

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,14 +33,14 @@ git clone https://github.com/my-entourage/claude-logger.git
 cd claude-logger
 
 # 3. Install (choose one)
-./install.sh --global              # User-level: all projects, sessions in ~/.claude-logger/
+./install.sh --global              # User-level: all projects, sessions organized by org/repo
 ./install.sh ~/path/to/project     # Project-level: single project, sessions in project/.claude/
 
-# 4. Add to your shell profile (.bashrc, .zshrc, etc.)
+# 4. For project-level installs, add to your shell profile (.bashrc, .zshrc, etc.)
 export CLAUDE_LOGGER_USER="your-nickname"
 ```
 
-Session data is captured automatically on every Claude Code session when `CLAUDE_LOGGER_USER` is set.
+Session data is captured automatically on every Claude Code session. For project-level installs, `CLAUDE_LOGGER_USER` must be set. Global installs organize by git org/repo automatically.
 
 **[Full Getting Started Guide](docs/GETTING-STARTED.md)** - detailed installation, verification, and usage instructions.
 
@@ -52,10 +52,12 @@ Uses Claude Code's `SessionStart`, `SessionEnd`, and `PreCompact` hooks to captu
 
 **Our enrichment (depends on install mode):**
 
-| Mode | Sessions Stored At |
-|------|-------------------|
-| Global (`--global`) | `~/.claude-logger/sessions/{nickname}/{session_id}.json` |
-| Project (default) | `PROJECT/.claude/sessions/{nickname}/{session_id}.json` |
+| Mode | Sessions Stored At | Username Required |
+|------|-------------------|-------------------|
+| Global (`--global`) | `~/.claude-logger/sessions/{org}/{repo}/{session_id}.json` | No |
+| Project (default) | `PROJECT/.claude/sessions/{username}/{session_id}.json` | Yes |
+
+Global mode extracts org/repo from git remote (e.g., `github.com/my-org/my-repo` → `my-org/my-repo/`). Falls back to `_local/{dirname}` for repos without remote.
 
 Linked by `session_id`. Query both together for complete picture.
 
@@ -65,7 +67,7 @@ The installer also adds `permissions.deny` rules to prevent Claude from accident
 
 ```json
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "session_id": "abc-123",
   "transcript_path": "~/.claude/projects/.../abc-123.jsonl",
   "status": "complete",
@@ -76,6 +78,9 @@ The installer also adds `permissions.deny` rules to prevent Claude from accident
     "git": {
       "sha": "abc123",
       "branch": "main",
+      "org": "my-org",
+      "repo": "my-repo",
+      "is_repo": true,
       "dirty": true,
       "dirty_files": ["src/foo.ts"],
       "dirty_count": 1

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -1,37 +1,41 @@
 # Upgrading Claude Logger
 
-This guide covers upgrading from a previous version of Claude Logger to the current version with user-based session organization and optional global installation.
+This guide covers upgrading from a previous version of Claude Logger.
 
 ## What Changed
 
-### Session Organization (Per-User)
+### Schema Version 2 (Project Organization)
 
-Sessions are now organized by user:
+Sessions now include `org` and `repo` fields in the git metadata, extracted from the git remote URL.
 
-| Version | Session Path |
-|---------|--------------|
-| Old | `.claude/sessions/{session_id}.json` |
-| New | `.claude/sessions/{nickname}/{session_id}.json` |
+### Global Mode: Org/Repo Organization
 
-This allows teams to track sessions per-user and requires the `CLAUDE_LOGGER_USER` environment variable.
+Global mode now organizes sessions by git org/repo instead of username:
 
-### Global Installation Mode (New)
+| Version | Global Session Path |
+|---------|---------------------|
+| Old | `~/.claude-logger/sessions/{username}/{session_id}.json` |
+| New | `~/.claude-logger/sessions/{org}/{repo}/{session_id}.json` |
 
-You can now install claude-logger once for all projects using `--global`:
+This provides better organization when working across multiple repositories.
 
-| Mode | Command | Sessions Stored At |
-|------|---------|-------------------|
-| Project (existing) | `./install.sh /path/to/project` | `PROJECT/.claude/sessions/{nickname}/` |
-| Global (new) | `./install.sh --global` | `~/.claude-logger/sessions/{nickname}/` |
+### Username No Longer Required for Global Mode
+
+The `CLAUDE_LOGGER_USER` environment variable is now optional for global installs. Sessions are automatically organized by git org/repo.
+
+| Mode | Command | Sessions Stored At | Username Required |
+|------|---------|-------------------|-------------------|
+| Project | `./install.sh /path/to/project` | `PROJECT/.claude/sessions/{username}/` | Yes |
+| Global | `./install.sh --global` | `~/.claude-logger/sessions/{org}/{repo}/` | No |
 
 ## Upgrade Steps
 
-### 1. Update Your Shell Profile
+### 1. Update Your Shell Profile (Project Mode Only)
 
-Add `CLAUDE_LOGGER_USER` to your shell profile (`.bashrc`, `.zshrc`, etc.):
+For project-level installs, ensure `CLAUDE_LOGGER_USER` is set in your shell profile (`.bashrc`, `.zshrc`, etc.):
 
 ```bash
-export CLAUDE_LOGGER_USER="your-nickname"
+export CLAUDE_LOGGER_USER="your-username"
 ```
 
 Then reload:
@@ -39,6 +43,8 @@ Then reload:
 ```bash
 source ~/.zshrc  # or your profile file
 ```
+
+For global installs, this step is optional - sessions are organized by git org/repo automatically.
 
 ### 2. Re-run the Installer
 
@@ -102,7 +108,7 @@ Instead of maintaining hooks in each project, use global mode:
 ./install.sh --global
 ```
 
-This installs hooks once at `~/.claude/hooks/` and stores all sessions at `~/.claude-logger/sessions/`. Each session records which project it was run in via the `cwd` field.
+This installs hooks once at `~/.claude/hooks/` and stores all sessions at `~/.claude-logger/sessions/{org}/{repo}/`. Sessions are automatically organized by the git remote origin, making it easy to find sessions for any project.
 
 **Note:** Global mode takes precedence. Once installed globally, even project-installed hooks will route sessions to the global location.
 

--- a/hooks/tests/test_extract_org_repo.sh
+++ b/hooks/tests/test_extract_org_repo.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+#
+# Tests for extract_org_repo function
+#
+
+#######################################
+# Define extract_org_repo function (same as in session_start.sh)
+# We define it here to avoid sourcing the full hook which blocks on stdin
+#######################################
+extract_org_repo() {
+  local dir="$1"
+  local git_timeout=3
+  local remote_url org repo
+
+  remote_url=$(git -C "$dir" remote get-url origin 2>/dev/null)
+
+  if [ -n "$remote_url" ]; then
+    if [[ "$remote_url" =~ git@[^:]+:([^/]+)/([^/]+)(\.git)?$ ]]; then
+      org="${BASH_REMATCH[1]}"
+      repo="${BASH_REMATCH[2]%.git}"
+    elif [[ "$remote_url" =~ https?://[^/]+/([^/]+)/([^/]+)(\.git)?$ ]]; then
+      org="${BASH_REMATCH[1]}"
+      repo="${BASH_REMATCH[2]%.git}"
+    fi
+
+    if [ -n "$org" ] && [ -n "$repo" ]; then
+      echo "$org" "$repo"
+      return 0
+    fi
+  fi
+
+  local dirname
+  dirname=$(basename "$dir")
+  echo "_local" "$dirname"
+}
+
+#######################################
+# Test: SSH URL parsing (standard format)
+#######################################
+test_start "extract_org_repo: parses SSH URL (git@github.com:org/repo.git)"
+setup_test_env
+
+# Create a git repo with SSH remote
+git -C "$TEST_TMPDIR" init -q
+git -C "$TEST_TMPDIR" remote add origin "git@github.com:my-org/my-repo.git"
+
+read -r org repo <<< "$(extract_org_repo "$TEST_TMPDIR")"
+
+if [ "$org" = "my-org" ] && [ "$repo" = "my-repo" ]; then
+  test_pass "org=$org, repo=$repo"
+else
+  test_fail "Expected org=my-org, repo=my-repo, got org=$org, repo=$repo"
+fi
+
+cleanup_test_env
+
+#######################################
+# Test: SSH URL without .git suffix
+#######################################
+test_start "extract_org_repo: parses SSH URL without .git suffix"
+setup_test_env
+
+git -C "$TEST_TMPDIR" init -q
+git -C "$TEST_TMPDIR" remote add origin "git@github.com:anthropic/claude"
+
+read -r org repo <<< "$(extract_org_repo "$TEST_TMPDIR")"
+
+if [ "$org" = "anthropic" ] && [ "$repo" = "claude" ]; then
+  test_pass "org=$org, repo=$repo"
+else
+  test_fail "Expected org=anthropic, repo=claude, got org=$org, repo=$repo"
+fi
+
+cleanup_test_env
+
+#######################################
+# Test: HTTPS URL parsing
+#######################################
+test_start "extract_org_repo: parses HTTPS URL"
+setup_test_env
+
+git -C "$TEST_TMPDIR" init -q
+git -C "$TEST_TMPDIR" remote add origin "https://github.com/my-entourage/claude-logger.git"
+
+read -r org repo <<< "$(extract_org_repo "$TEST_TMPDIR")"
+
+if [ "$org" = "my-entourage" ] && [ "$repo" = "claude-logger" ]; then
+  test_pass "org=$org, repo=$repo"
+else
+  test_fail "Expected org=my-entourage, repo=claude-logger, got org=$org, repo=$repo"
+fi
+
+cleanup_test_env
+
+#######################################
+# Test: HTTPS URL without .git suffix
+#######################################
+test_start "extract_org_repo: parses HTTPS URL without .git suffix"
+setup_test_env
+
+git -C "$TEST_TMPDIR" init -q
+git -C "$TEST_TMPDIR" remote add origin "https://github.com/owner/project"
+
+read -r org repo <<< "$(extract_org_repo "$TEST_TMPDIR")"
+
+if [ "$org" = "owner" ] && [ "$repo" = "project" ]; then
+  test_pass "org=$org, repo=$repo"
+else
+  test_fail "Expected org=owner, repo=project, got org=$org, repo=$repo"
+fi
+
+cleanup_test_env
+
+#######################################
+# Test: HTTP URL (non-HTTPS)
+#######################################
+test_start "extract_org_repo: parses HTTP URL"
+setup_test_env
+
+git -C "$TEST_TMPDIR" init -q
+git -C "$TEST_TMPDIR" remote add origin "http://github.com/test-org/test-repo.git"
+
+read -r org repo <<< "$(extract_org_repo "$TEST_TMPDIR")"
+
+if [ "$org" = "test-org" ] && [ "$repo" = "test-repo" ]; then
+  test_pass "org=$org, repo=$repo"
+else
+  test_fail "Expected org=test-org, repo=test-repo, got org=$org, repo=$repo"
+fi
+
+cleanup_test_env
+
+#######################################
+# Test: GitLab SSH URL
+#######################################
+test_start "extract_org_repo: parses GitLab SSH URL"
+setup_test_env
+
+git -C "$TEST_TMPDIR" init -q
+git -C "$TEST_TMPDIR" remote add origin "git@gitlab.com:company/project.git"
+
+read -r org repo <<< "$(extract_org_repo "$TEST_TMPDIR")"
+
+if [ "$org" = "company" ] && [ "$repo" = "project" ]; then
+  test_pass "org=$org, repo=$repo"
+else
+  test_fail "Expected org=company, repo=project, got org=$org, repo=$repo"
+fi
+
+cleanup_test_env
+
+#######################################
+# Test: Fallback for no remote (local git repo)
+#######################################
+test_start "extract_org_repo: falls back to _local for repo without remote"
+setup_test_env
+
+# Create a git repo without any remote
+git -C "$TEST_TMPDIR" init -q
+
+read -r org repo <<< "$(extract_org_repo "$TEST_TMPDIR")"
+
+expected_dirname=$(basename "$TEST_TMPDIR")
+if [ "$org" = "_local" ] && [ "$repo" = "$expected_dirname" ]; then
+  test_pass "org=$org, repo=$repo"
+else
+  test_fail "Expected org=_local, repo=$expected_dirname, got org=$org, repo=$repo"
+fi
+
+cleanup_test_env
+
+#######################################
+# Test: Fallback for non-git directory
+#######################################
+test_start "extract_org_repo: falls back to _local for non-git directory"
+setup_test_env
+
+# Use a subdirectory that's not a git repo
+NON_GIT_DIR="$TEST_TMPDIR/my-local-project"
+mkdir -p "$NON_GIT_DIR"
+
+read -r org repo <<< "$(extract_org_repo "$NON_GIT_DIR")"
+
+if [ "$org" = "_local" ] && [ "$repo" = "my-local-project" ]; then
+  test_pass "org=$org, repo=$repo"
+else
+  test_fail "Expected org=_local, repo=my-local-project, got org=$org, repo=$repo"
+fi
+
+cleanup_test_env
+
+#######################################
+# Test: Org/repo with special characters (dashes, underscores)
+#######################################
+test_start "extract_org_repo: handles org/repo with dashes and underscores"
+setup_test_env
+
+git -C "$TEST_TMPDIR" init -q
+git -C "$TEST_TMPDIR" remote add origin "git@github.com:my-org_123/my_repo-456.git"
+
+read -r org repo <<< "$(extract_org_repo "$TEST_TMPDIR")"
+
+if [ "$org" = "my-org_123" ] && [ "$repo" = "my_repo-456" ]; then
+  test_pass "org=$org, repo=$repo"
+else
+  test_fail "Expected org=my-org_123, repo=my_repo-456, got org=$org, repo=$repo"
+fi
+
+cleanup_test_env
+
+#######################################
+# Test: Bitbucket SSH URL format
+#######################################
+test_start "extract_org_repo: parses Bitbucket SSH URL"
+setup_test_env
+
+git -C "$TEST_TMPDIR" init -q
+git -C "$TEST_TMPDIR" remote add origin "git@bitbucket.org:workspace/repo-name.git"
+
+read -r org repo <<< "$(extract_org_repo "$TEST_TMPDIR")"
+
+if [ "$org" = "workspace" ] && [ "$repo" = "repo-name" ]; then
+  test_pass "org=$org, repo=$repo"
+else
+  test_fail "Expected org=workspace, repo=repo-name, got org=$org, repo=$repo"
+fi
+
+cleanup_test_env

--- a/hooks/tests/test_production_edge_cases.sh
+++ b/hooks/tests/test_production_edge_cases.sh
@@ -50,7 +50,7 @@ echo '{"type":"user","message":"hello"}' > "$transcript_path"
 # Create session with transcript path
 cat > "$TEST_TMPDIR/.claude/sessions/$CLAUDE_LOGGER_USER/deleted-transcript.json" << EOF
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "session_id": "deleted-transcript",
   "transcript_path": "$transcript_path",
   "status": "in_progress",
@@ -100,7 +100,7 @@ git -C "$TEST_TMPDIR" commit -q -m "Initial"
 # Create session with a transcript path that points to wrong location
 cat > "$TEST_TMPDIR/.claude/sessions/$CLAUDE_LOGGER_USER/wrong-path.json" << EOF
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "session_id": "wrong-path",
   "transcript_path": "/nonexistent/path/to/transcript.jsonl",
   "status": "in_progress",
@@ -191,7 +191,7 @@ setup_test_env
 for i in $(seq 1 5); do
   cat > "$TEST_TMPDIR/.claude/sessions/$CLAUDE_LOGGER_USER/rapid-orphan-$i.json" << EOF
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "session_id": "rapid-orphan-$i",
   "status": "in_progress",
   "start": {"timestamp": "2025-01-01T12:0$i:00Z", "cwd": "$TEST_TMPDIR"}
@@ -242,7 +242,7 @@ start_timestamp="2025-01-01T00:00:00Z"  # 30 hours ago (simulated)
 
 cat > "$TEST_TMPDIR/.claude/sessions/$CLAUDE_LOGGER_USER/zombie-session.json" << EOF
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "session_id": "zombie-session",
   "status": "in_progress",
   "start": {
@@ -320,7 +320,7 @@ done
 # Create session that claims to have started at old_sha
 cat > "$TEST_TMPDIR/.claude/sessions/$CLAUDE_LOGGER_USER/stale-sha-session.json" << EOF
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "session_id": "stale-sha-session",
   "status": "in_progress",
   "start": {
@@ -374,7 +374,7 @@ git -C "$TEST_TMPDIR" commit -q -m "Initial"
 # Create first session
 cat > "$TEST_TMPDIR/.claude/sessions/$CLAUDE_LOGGER_USER/ending-session.json" << EOF
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "session_id": "ending-session",
   "status": "in_progress",
   "start": {
@@ -426,7 +426,7 @@ git -C "$TEST_TMPDIR" commit -q -m "Initial"
 
 cat > "$TEST_TMPDIR/.claude/sessions/$CLAUDE_LOGGER_USER/other-reason.json" << EOF
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "session_id": "other-reason",
   "status": "in_progress",
   "start": {
@@ -465,7 +465,7 @@ for user in "alice" "bob"; do
 
   cat > "$TEST_TMPDIR/.claude/sessions/$user/user-session.json" << EOF
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "session_id": "user-session",
   "status": "in_progress",
   "start": {"timestamp": "2025-01-01T12:00:00Z", "cwd": "$TEST_TMPDIR"}
@@ -506,7 +506,7 @@ git -C "$TEST_TMPDIR" commit -q -m "Initial"
 # Create session with extra fields (simulating legacy/future schema)
 cat > "$TEST_TMPDIR/.claude/sessions/$CLAUDE_LOGGER_USER/extra-fields.json" << EOF
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "session_id": "extra-fields",
   "status": "in_progress",
   "legacy_field": "should_be_preserved",
@@ -553,7 +553,7 @@ touch "$transcript_path"  # 0 bytes
 
 cat > "$TEST_TMPDIR/.claude/sessions/$CLAUDE_LOGGER_USER/empty-transcript-session.json" << EOF
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "session_id": "empty-transcript-session",
   "transcript_path": "$transcript_path",
   "status": "in_progress",

--- a/hooks/tests/test_runner.sh
+++ b/hooks/tests/test_runner.sh
@@ -39,6 +39,12 @@ TEST_TMPDIR=""
 setup_test_env() {
   TEST_TMPDIR=$(mktemp -d)
 
+  # Mock HOME to isolate tests from real user environment
+  # This ensures tests don't pick up global-mode marker from real ~/.claude-logger
+  ORIGINAL_HOME="$HOME"
+  export HOME="$TEST_TMPDIR/mock-home"
+  mkdir -p "$HOME"
+
   # Set test user for session tracking
   export CLAUDE_LOGGER_USER="test-user"
 
@@ -56,6 +62,11 @@ setup_test_env() {
 
 # Cleanup test environment
 cleanup_test_env() {
+  # Restore original HOME
+  if [ -n "$ORIGINAL_HOME" ]; then
+    export HOME="$ORIGINAL_HOME"
+  fi
+
   if [ -n "$TEST_TMPDIR" ] && [ -d "$TEST_TMPDIR" ]; then
     rm -rf "$TEST_TMPDIR"
   fi

--- a/hooks/tests/test_session_end.sh
+++ b/hooks/tests/test_session_end.sh
@@ -13,7 +13,7 @@ create_started_session() {
 
   cat > "$session_file" << EOF
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "session_id": "$session_id",
   "transcript_path": "/tmp/test.jsonl",
   "status": "in_progress",
@@ -879,7 +879,7 @@ mkdir -p "$TEST_TMPDIR/.claude/sessions/$CLAUDE_LOGGER_USER"
 session_file="$TEST_TMPDIR/.claude/sessions/$CLAUDE_LOGGER_USER/test-end-subdir.json"
 cat > "$session_file" << 'EOF'
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "session_id": "test-end-subdir",
   "transcript_path": "",
   "status": "in_progress",

--- a/hooks/tests/test_session_start.sh
+++ b/hooks/tests/test_session_start.sh
@@ -348,7 +348,7 @@ run_hook "session_start.sh" "$input"
 
 session_file="$TEST_TMPDIR/.claude/sessions/$CLAUDE_LOGGER_USER/test-schema.json"
 if assert_file_exists "$session_file" && \
-   assert_json_value "$session_file" '.schema_version' '1'; then
+   assert_json_value "$session_file" '.schema_version' '2'; then
   test_pass
 fi
 

--- a/tests/test_global_install.sh
+++ b/tests/test_global_install.sh
@@ -57,9 +57,9 @@ test_fail() {
 }
 
 # Run install.sh --global with mocked HOME
+# Global mode no longer requires username input
 run_global_install() {
-  local nickname="$1"
-  echo "$nickname" | HOME="$MOCK_HOME" bash "$REPO_DIR/install.sh" --global 2>&1
+  HOME="$MOCK_HOME" bash "$REPO_DIR/install.sh" --global 2>&1
 }
 
 # Run install.sh for project (existing behavior)
@@ -185,18 +185,18 @@ fi
 cleanup_test
 
 #######################################
-# Test: --global success message shows global path
+# Test: --global success message shows org/repo path format
 #######################################
-test_start "--global success message shows global session path"
+test_start "--global success message shows org/repo session path"
 setup_test
 
-# Set env var to expected value so output message matches
-CLAUDE_LOGGER_USER="testuser" output=$(run_global_install "testuser")
+output=$(run_global_install)
 
-if echo "$output" | grep -q "\.claude-logger/sessions/testuser"; then
+if echo "$output" | grep -q "~/.claude-logger/sessions/{org}/{repo}/"; then
   test_pass
 else
-  test_fail "success message doesn't show global path"
+  test_fail "success message doesn't show org/repo path format"
+  echo "Output was: $output"
 fi
 
 cleanup_test
@@ -224,16 +224,18 @@ fi
 cleanup_test
 
 #######################################
-# Test: Hook uses global storage when marker exists
+# Test: Hook uses global storage when marker exists (with git remote)
 #######################################
-test_start "hook stores sessions globally when marker exists"
+test_start "hook stores sessions globally by org/repo when marker exists"
 setup_test
 
 # Install globally
-run_global_install "testuser" > /dev/null
+run_global_install > /dev/null
 
-# Create a test project directory
+# Create a test project directory with git remote
 mkdir -p "$TEST_TMPDIR/project"
+git -C "$TEST_TMPDIR/project" init -q
+git -C "$TEST_TMPDIR/project" remote add origin "git@github.com:test-org/test-repo.git"
 
 # Run session_start hook with mocked HOME
 SESSION_ID="test-session-global-$(date +%s)"
@@ -246,17 +248,23 @@ HOOK_INPUT=$(cat <<EOF
 EOF
 )
 
-echo "$HOOK_INPUT" | HOME="$MOCK_HOME" CLAUDE_LOGGER_USER="testuser" bash "$MOCK_HOME/.claude/hooks/session_start.sh" 2>/dev/null
+echo "$HOOK_INPUT" | HOME="$MOCK_HOME" bash "$MOCK_HOME/.claude/hooks/session_start.sh" 2>/dev/null
 
-# Check session was created in global location
-if [ -f "$MOCK_HOME/.claude-logger/sessions/testuser/$SESSION_ID.json" ]; then
-  test_pass
+# Check session was created in global location organized by org/repo
+if [ -f "$MOCK_HOME/.claude-logger/sessions/test-org/test-repo/$SESSION_ID.json" ]; then
+  test_pass "session stored at org/repo path"
 else
   # Check if it was created in project (wrong)
-  if [ -f "$TEST_TMPDIR/project/.claude/sessions/testuser/$SESSION_ID.json" ]; then
+  if find "$TEST_TMPDIR/project/.claude/sessions" -name "$SESSION_ID.json" 2>/dev/null | grep -q .; then
     test_fail "session created in project instead of global"
   else
-    test_fail "session file not created anywhere"
+    # Check if it's somewhere else in global
+    found_path=$(find "$MOCK_HOME/.claude-logger/sessions" -name "$SESSION_ID.json" 2>/dev/null | head -1)
+    if [ -n "$found_path" ]; then
+      test_fail "session created at wrong path: $found_path"
+    else
+      test_fail "session file not created anywhere"
+    fi
   fi
 fi
 
@@ -300,7 +308,12 @@ test_start "session_end respects global mode"
 setup_test
 
 # Install globally
-run_global_install "testuser" > /dev/null
+run_global_install > /dev/null
+
+# Create project with git remote
+mkdir -p "$TEST_TMPDIR/project"
+git -C "$TEST_TMPDIR/project" init -q
+git -C "$TEST_TMPDIR/project" remote add origin "git@github.com:end-org/end-repo.git"
 
 # Create session via start hook
 SESSION_ID="test-session-end-$(date +%s)"
@@ -313,7 +326,7 @@ START_INPUT=$(cat <<EOF
 EOF
 )
 
-echo "$START_INPUT" | HOME="$MOCK_HOME" CLAUDE_LOGGER_USER="testuser" bash "$MOCK_HOME/.claude/hooks/session_start.sh" 2>/dev/null
+echo "$START_INPUT" | HOME="$MOCK_HOME" bash "$MOCK_HOME/.claude/hooks/session_start.sh" 2>/dev/null
 
 # Run session_end hook
 END_INPUT=$(cat <<EOF
@@ -325,10 +338,10 @@ END_INPUT=$(cat <<EOF
 EOF
 )
 
-echo "$END_INPUT" | HOME="$MOCK_HOME" CLAUDE_LOGGER_USER="testuser" bash "$MOCK_HOME/.claude/hooks/session_end.sh" 2>/dev/null
+echo "$END_INPUT" | HOME="$MOCK_HOME" bash "$MOCK_HOME/.claude/hooks/session_end.sh" 2>/dev/null
 
 # Check session was completed
-SESSION_FILE="$MOCK_HOME/.claude-logger/sessions/testuser/$SESSION_ID.json"
+SESSION_FILE="$MOCK_HOME/.claude-logger/sessions/end-org/end-repo/$SESSION_ID.json"
 if [ -f "$SESSION_FILE" ]; then
   status=$(jq -r '.status' "$SESSION_FILE")
   if [ "$status" = "complete" ]; then
@@ -343,19 +356,20 @@ fi
 cleanup_test
 
 #######################################
-# Test: Global sessions still capture project context
+# Test: Global sessions capture project context and org/repo
 #######################################
-test_start "global sessions capture project cwd and git info"
+test_start "global sessions capture project cwd, git info, and org/repo"
 setup_test
 
 # Install globally
-run_global_install "testuser" > /dev/null
+run_global_install > /dev/null
 
-# Create a git repo in project
+# Create a git repo in project with remote
 mkdir -p "$TEST_TMPDIR/project"
 git -C "$TEST_TMPDIR/project" init -q
 git -C "$TEST_TMPDIR/project" config user.email "test@test.com"
 git -C "$TEST_TMPDIR/project" config user.name "Test"
+git -C "$TEST_TMPDIR/project" remote add origin "https://github.com/context-org/context-repo.git"
 echo "test" > "$TEST_TMPDIR/project/file.txt"
 git -C "$TEST_TMPDIR/project" add .
 git -C "$TEST_TMPDIR/project" commit -q -m "initial"
@@ -371,21 +385,24 @@ HOOK_INPUT=$(cat <<EOF
 EOF
 )
 
-echo "$HOOK_INPUT" | HOME="$MOCK_HOME" CLAUDE_LOGGER_USER="testuser" bash "$MOCK_HOME/.claude/hooks/session_start.sh" 2>/dev/null
+echo "$HOOK_INPUT" | HOME="$MOCK_HOME" bash "$MOCK_HOME/.claude/hooks/session_start.sh" 2>/dev/null
 
-# Check session captures project context
-SESSION_FILE="$MOCK_HOME/.claude-logger/sessions/testuser/$SESSION_ID.json"
+# Check session captures project context including org/repo
+SESSION_FILE="$MOCK_HOME/.claude-logger/sessions/context-org/context-repo/$SESSION_ID.json"
 if [ -f "$SESSION_FILE" ]; then
   cwd=$(jq -r '.start.cwd' "$SESSION_FILE")
   is_repo=$(jq -r '.start.git.is_repo' "$SESSION_FILE")
+  org=$(jq -r '.start.git.org' "$SESSION_FILE")
+  repo=$(jq -r '.start.git.repo' "$SESSION_FILE")
 
-  if [ "$cwd" = "$TEST_TMPDIR/project" ] && [ "$is_repo" = "true" ]; then
-    test_pass "cwd=$cwd, is_repo=$is_repo"
+  if [ "$cwd" = "$TEST_TMPDIR/project" ] && [ "$is_repo" = "true" ] && \
+     [ "$org" = "context-org" ] && [ "$repo" = "context-repo" ]; then
+    test_pass "cwd=$cwd, is_repo=$is_repo, org=$org, repo=$repo"
   else
-    test_fail "cwd=$cwd, is_repo=$is_repo"
+    test_fail "cwd=$cwd, is_repo=$is_repo, org=$org, repo=$repo"
   fi
 else
-  test_fail "session file not found"
+  test_fail "session file not found at expected path"
 fi
 
 cleanup_test
@@ -399,10 +416,12 @@ test_start "project-installed hooks respect global-mode marker"
 setup_test
 
 # First, do a global install to create the marker
-run_global_install "testuser" > /dev/null
+run_global_install > /dev/null
 
 # Then, install to a project directory (simulating outdated hooks scenario)
 mkdir -p "$TEST_TMPDIR/project"
+git -C "$TEST_TMPDIR/project" init -q
+git -C "$TEST_TMPDIR/project" remote add origin "git@github.com:respect-org/respect-repo.git"
 run_project_install "$TEST_TMPDIR/project" "testuser" > /dev/null
 
 # The global-mode marker should still exist
@@ -421,19 +440,109 @@ else
 EOF
 )
 
-  echo "$HOOK_INPUT" | HOME="$MOCK_HOME" CLAUDE_LOGGER_USER="testuser" bash "$TEST_TMPDIR/project/.claude/hooks/session_start.sh" 2>/dev/null
+  echo "$HOOK_INPUT" | HOME="$MOCK_HOME" bash "$TEST_TMPDIR/project/.claude/hooks/session_start.sh" 2>/dev/null
 
-  # Check session was created in GLOBAL location (because marker exists)
-  if [ -f "$MOCK_HOME/.claude-logger/sessions/testuser/$SESSION_ID.json" ]; then
-    test_pass "project hooks correctly routed to global storage"
+  # Check session was created in GLOBAL location by org/repo (because marker exists)
+  if [ -f "$MOCK_HOME/.claude-logger/sessions/respect-org/respect-repo/$SESSION_ID.json" ]; then
+    test_pass "project hooks correctly routed to global storage by org/repo"
   else
     # Check if it was created in project (wrong - should respect global marker)
-    if [ -f "$TEST_TMPDIR/project/.claude/sessions/testuser/$SESSION_ID.json" ]; then
+    if find "$TEST_TMPDIR/project/.claude/sessions" -name "$SESSION_ID.json" 2>/dev/null | grep -q .; then
       test_fail "project hooks ignored global-mode marker - stored in project instead"
     else
-      test_fail "session file not created anywhere"
+      found_path=$(find "$MOCK_HOME/.claude-logger/sessions" -name "$SESSION_ID.json" 2>/dev/null | head -1)
+      if [ -n "$found_path" ]; then
+        test_fail "session created at wrong path: $found_path"
+      else
+        test_fail "session file not created anywhere"
+      fi
     fi
   fi
+fi
+
+cleanup_test
+
+#######################################
+# Test: Global mode falls back to _local for repos without remote
+#######################################
+test_start "global mode uses _local/{dirname} for repos without remote"
+setup_test
+
+# Install globally
+run_global_install > /dev/null
+
+# Create a git repo WITHOUT remote
+mkdir -p "$TEST_TMPDIR/my-local-project"
+git -C "$TEST_TMPDIR/my-local-project" init -q
+
+# Run session_start hook
+SESSION_ID="test-session-local-$(date +%s)"
+HOOK_INPUT=$(cat <<EOF
+{
+  "session_id": "$SESSION_ID",
+  "cwd": "$TEST_TMPDIR/my-local-project",
+  "transcript_path": "/tmp/transcript.jsonl"
+}
+EOF
+)
+
+echo "$HOOK_INPUT" | HOME="$MOCK_HOME" bash "$MOCK_HOME/.claude/hooks/session_start.sh" 2>/dev/null
+
+# Check session was created in _local/dirname path
+if [ -f "$MOCK_HOME/.claude-logger/sessions/_local/my-local-project/$SESSION_ID.json" ]; then
+  # Also verify org/repo in metadata
+  org=$(jq -r '.start.git.org' "$MOCK_HOME/.claude-logger/sessions/_local/my-local-project/$SESSION_ID.json")
+  repo=$(jq -r '.start.git.repo' "$MOCK_HOME/.claude-logger/sessions/_local/my-local-project/$SESSION_ID.json")
+  if [ "$org" = "_local" ] && [ "$repo" = "my-local-project" ]; then
+    test_pass "session at _local/my-local-project with correct metadata"
+  else
+    test_fail "metadata wrong: org=$org, repo=$repo"
+  fi
+else
+  found_path=$(find "$MOCK_HOME/.claude-logger/sessions" -name "$SESSION_ID.json" 2>/dev/null | head -1)
+  if [ -n "$found_path" ]; then
+    test_fail "session created at wrong path: $found_path"
+  else
+    test_fail "session file not created anywhere"
+  fi
+fi
+
+cleanup_test
+
+#######################################
+# Test: Global mode doesn't require CLAUDE_LOGGER_USER
+#######################################
+test_start "global mode works without CLAUDE_LOGGER_USER env var"
+setup_test
+
+# Install globally
+run_global_install > /dev/null
+
+# Create a project with remote
+mkdir -p "$TEST_TMPDIR/project"
+git -C "$TEST_TMPDIR/project" init -q
+git -C "$TEST_TMPDIR/project" remote add origin "git@github.com:no-user-org/no-user-repo.git"
+
+# Run session_start hook WITHOUT setting CLAUDE_LOGGER_USER
+SESSION_ID="test-session-no-user-$(date +%s)"
+HOOK_INPUT=$(cat <<EOF
+{
+  "session_id": "$SESSION_ID",
+  "cwd": "$TEST_TMPDIR/project",
+  "transcript_path": "/tmp/transcript.jsonl"
+}
+EOF
+)
+
+# Explicitly unset CLAUDE_LOGGER_USER
+unset CLAUDE_LOGGER_USER
+echo "$HOOK_INPUT" | HOME="$MOCK_HOME" bash "$MOCK_HOME/.claude/hooks/session_start.sh" 2>/dev/null
+
+# Check session was created (should work without username in global mode)
+if [ -f "$MOCK_HOME/.claude-logger/sessions/no-user-org/no-user-repo/$SESSION_ID.json" ]; then
+  test_pass "session created without CLAUDE_LOGGER_USER"
+else
+  test_fail "session not created without CLAUDE_LOGGER_USER"
 fi
 
 cleanup_test


### PR DESCRIPTION
## Summary

- Global mode now organizes sessions by git org/repo instead of username
- Extracts org/repo from git remote URL (SSH or HTTPS)
- Falls back to `_local/{dirname}` for repos without remote
- Username (`CLAUDE_LOGGER_USER`) no longer required for global mode
- Adds `org` and `repo` fields to session metadata
- Bumps schema_version to 2

## Directory Structure

**Global mode (new):**
```
~/.claude-logger/sessions/
├── my-org/
│   └── my-repo/
│       └── {session_id}.json
└── _local/
    └── local-project/
        └── {session_id}.json
```

**Project mode (unchanged):**
```
PROJECT/.claude/sessions/{username}/{session_id}.json
```

## Test plan

- [x] All automated tests pass (220 tests)
- [ ] Manual: Fresh global install shows `{org}/{repo}` path format
- [ ] Manual: Session created in correct org/repo directory
- [ ] Manual: `/compact` creates precompact snapshot
- [ ] Manual: `/clear` creates preclear snapshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)